### PR TITLE
Fix Number of Shards Generated

### DIFF
--- a/interplm/concept/extract_uniprotkb_annotations.py
+++ b/interplm/concept/extract_uniprotkb_annotations.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import logging
+from math import ceil
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -172,7 +173,7 @@ def shard_protein_data(
     n_shards: int,
 ) -> None:
     """Split preprocessed data into shards for parallel processing."""
-    shard_size = len(df) // n_shards
+    shard_size = ceil(len(df) / n_shards)
     for i in range(0, len(df), shard_size):
         shard_id = i // shard_size
         df_shard = df.iloc[i : min(i + shard_size, len(df))].reset_index(drop=True)


### PR DESCRIPTION
There's a very subtle bug in how the sharding is done leading to `n_shards + 1` shards being generated and the last shard not being processed in the main method. By setting `shard_size = len(df) // n_shards` the `range` object will iterate `n_shards` times normally, but in the case of `n_shards` not perfectly dividing `len(df)` there will be an extra `n_shards + 1`th iteration as `n_shards * shard_size < len(df)`.

Overall, I don't think this issue changes results in any major way! Just small quirk.

A quick fix is to perform division and then use the ceiling operator, which will work so long as `n_shards << len(df)`.

Changes tested by hand!